### PR TITLE
xorg-proto: patch from newer dunfell release to fix build with python >= 3.9

### DIFF
--- a/recipes-graphics/xorg-proto/files/0001-xcbgen-use-math-gcd-for-python-3-5.patch
+++ b/recipes-graphics/xorg-proto/files/0001-xcbgen-use-math-gcd-for-python-3-5.patch
@@ -1,0 +1,40 @@
+From 426ae35bee1fa0fdb8b5120b1dcd20cee6e34512 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 1 Jun 2020 12:24:16 +0200
+Subject: [PATCH] xcbgen: Use math.gcd() for Python >= 3.5.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+fractions.gcd() has been deprecated since Python 3.5, and
+was finally dropped in Python 3.9.  It is recommended to
+use math.gcd() instead.
+
+Signed-off-by: Björn Esser <besser82@fedoraproject.org>
+Upstream-Status: Backport [https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/commit/426ae35bee1fa0fdb8b5120b1dcd20cee6e34512]
+Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+---
+ xcbgen/align.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/xcbgen/align.py b/xcbgen/align.py
+index d4c12ee..5c4f517 100644
+--- a/xcbgen/align.py
++++ b/xcbgen/align.py
+@@ -2,7 +2,12 @@
+ This module contains helper classes for alignment arithmetic and checks
+ '''
+ 
+-from fractions import gcd
++from sys import version_info
++
++if version_info[:2] >= (3, 5):
++    from math import gcd
++else:
++    from fractions import gcd
+ 
+ class Alignment(object):
+ 
+-- 
+GitLab
+

--- a/recipes-graphics/xorg-proto/xcb-proto_1.13.bb
+++ b/recipes-graphics/xorg-proto/xcb-proto_1.13.bb
@@ -1,0 +1,30 @@
+SUMMARY = "XCB: The X protocol C binding headers"
+DESCRIPTION = "Function prototypes for the X protocol C-language Binding \
+(XCB).  XCB is a replacement for Xlib featuring a small footprint, \
+latency hiding, direct access to the protocol, improved threading \
+support, and extensibility."
+HOMEPAGE = "http://xcb.freedesktop.org"
+BUGTRACKER = "https://bugs.freedesktop.org/enter_bug.cgi?product=XCB"
+
+SECTION = "x11/libs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d763b081cb10c223435b01e00dc0aba7 \
+                    file://src/dri2.xml;beginline=2;endline=28;md5=f8763b13ff432e8597e0d610cf598e65"
+
+SRC_URI = "http://xcb.freedesktop.org/dist/${BP}.tar.bz2 \
+           file://0001-xcbgen-use-math-gcd-for-python-3-5.patch"
+SRC_URI[md5sum] = "abe9aa4886138150bbc04ae4f29b90e3"
+SRC_URI[sha256sum] = "7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1"
+
+inherit autotools pkgconfig python3native
+
+PACKAGES += "python-xcbgen"
+
+FILES_${PN} = ""
+FILES_${PN}-dev += "${datadir}/xcb/*.xml ${datadir}/xcb/*.xsd"
+FILES_python-xcbgen = "${PYTHON_SITEPACKAGES_DIR}"
+
+RDEPENDS_${PN}-dev = ""
+RRECOMMENDS_${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION

Fix build for SDK with newer Python versions (ie. FC33 or later)