### PR TITLE
pppd: upgrade to 2.4.9 (from poky master, pre-new syntax conversion)

### DIFF
--- a/recipes-connectivity/ppp/ppp/08setupdns
+++ b/recipes-connectivity/ppp/ppp/08setupdns
@@ -1,0 +1,12 @@
+#!/bin/sh
+ACTUALCONF=/var/run/resolv.conf
+PPPCONF=/var/run/ppp/resolv.conf
+if [ -f $PPPCONF ] ; then
+	if [ -f $ACTUALCONF ] ; then
+		if [ ! -h $ACTUALCONF -o ! "`readlink $ACTUALCONF 2>&1`" = "$PPPCONF" ] ; then
+			mv $ACTUALCONF $ACTUALCONF.ppporig
+		fi
+	fi
+
+	ln -sf $PPPCONF $ACTUALCONF
+fi

--- a/recipes-connectivity/ppp/ppp/92removedns
+++ b/recipes-connectivity/ppp/ppp/92removedns
@@ -1,0 +1,5 @@
+#!/bin/sh
+ACTUALCONF=/var/run/resolv.conf
+if [ -f $ACTUALCONF.ppporig ] ; then
+	mv $ACTUALCONF.ppporig $ACTUALCONF
+fi

--- a/recipes-connectivity/ppp/ppp/init
+++ b/recipes-connectivity/ppp/ppp/init
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+#   /etc/init.d/ppp: start or stop PPP link.
+#
+# If you want PPP started on boot time (most dialup systems won't need it)
+# rename the /etc/ppp/no_ppp_on_boot file to /etc/ppp/ppp_on_boot, and
+# follow the instructions in the comments in that file.
+
+# Source function library.
+. /etc/init.d/functions
+
+test -x /usr/sbin/pppd -a -f /etc/ppp/ppp_on_boot || exit 0
+if [ -x /etc/ppp/ppp_on_boot ]; then RUNFILE=1; fi
+
+case "$1" in
+  start)
+      echo -n "Starting up PPP link: pppd"
+      if [ "$RUNFILE" = "1" ]; then
+        /etc/ppp/ppp_on_boot
+      else
+        pppd call provider
+      fi
+      echo "."
+    ;;
+  stop)
+      echo -n "Shutting down PPP link: pppd"
+      if [ "$RUNFILE" = "1" ]; then
+        poff
+      else
+        poff provider
+      fi
+      echo "."
+    ;;
+  status)
+    status /usr/sbin/pppd;
+    exit $?
+    ;;
+  restart|force-reload)
+    echo -n "Restarting PPP link: pppd"
+    if [ "$RUNFILE" = "1" ]; then      
+      poff
+      sleep 5
+      /etc/ppp/ppp_on_boot
+    else                  
+      poff provider
+      sleep 5
+      pppd call provider
+    fi
+    echo "."
+    ;;
+  *)
+      echo "Usage: /etc/init.d/ppp {start|stop|status|restart|force-reload}"
+      exit 1
+    ;;
+esac
+
+exit 0

--- a/recipes-connectivity/ppp/ppp/ip-down
+++ b/recipes-connectivity/ppp/ppp/ip-down
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# $Id: ip-down,v 1.2 1998/02/10 21:21:55 phil Exp $
+#
+# This script is run by the pppd _after_ the link is brought down.
+# It uses run-parts to run scripts in /etc/ppp/ip-down.d, so to delete
+# routes, unset IP addresses etc. you should create script(s) there.
+#
+# Be aware that other packages may include /etc/ppp/ip-down.d scripts (named
+# after that package), so choose local script names with that in mind.
+#
+# This script is called with the following arguments:
+#    Arg  Name                          Example
+#    $1   Interface name                ppp0
+#    $2   The tty                       ttyS1
+#    $3   The link speed                38400
+#    $4   Local IP number               12.34.56.78
+#    $5   Peer  IP number               12.34.56.99
+#    $6   Optional ``ipparam'' value    foo
+
+# The  environment is cleared before executing this script
+# so the path must be reset
+PATH=/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin
+export PATH
+# These variables are for the use of the scripts run by run-parts
+PPP_IFACE="$1"
+PPP_TTY="$2"
+PPP_SPEED="$3"
+PPP_LOCAL="$4"
+PPP_REMOTE="$5"
+PPP_IPPARAM="$6"
+export PPP_IFACE PPP_TTY PPP_SPEED PPP_LOCAL PPP_REMOTE PPP_IPPARAM
+
+# as an additional convenience, $PPP_TTYNAME is set to the tty name,
+# stripped of /dev/ (if present) for easier matching.
+PPP_TTYNAME=`/usr/bin/basename "$2"`
+export PPP_TTYNAME 
+
+# Main Script starts here
+
+run-parts /etc/ppp/ip-down.d
+
+# last line

--- a/recipes-connectivity/ppp/ppp/ip-up
+++ b/recipes-connectivity/ppp/ppp/ip-up
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# $Id: ip-up,v 1.2 1998/02/10 21:25:34 phil Exp $
+#
+# This script is run by the pppd after the link is established.
+# It uses run-parts to run scripts in /etc/ppp/ip-up.d, so to add routes,
+# set IP address, run the mailq etc. you should create script(s) there.
+#
+# Be aware that other packages may include /etc/ppp/ip-up.d scripts (named
+# after that package), so choose local script names with that in mind.
+#
+# This script is called with the following arguments:
+#    Arg  Name                          Example
+#    $1   Interface name                ppp0
+#    $2   The tty                       ttyS1
+#    $3   The link speed                38400
+#    $4   Local IP number               12.34.56.78
+#    $5   Peer  IP number               12.34.56.99
+#    $6   Optional ``ipparam'' value    foo
+
+# The  environment is cleared before executing this script
+# so the path must be reset
+PATH=/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin
+export PATH
+# These variables are for the use of the scripts run by run-parts
+PPP_IFACE="$1"
+PPP_TTY="$2"
+PPP_SPEED="$3"
+PPP_LOCAL="$4"
+PPP_REMOTE="$5"
+PPP_IPPARAM="$6"
+export PPP_IFACE PPP_TTY PPP_SPEED PPP_LOCAL PPP_REMOTE PPP_IPPARAM
+
+
+# as an additional convenience, $PPP_TTYNAME is set to the tty name,
+# stripped of /dev/ (if present) for easier matching.
+PPP_TTYNAME=`/usr/bin/basename "$2"`
+export PPP_TTYNAME 
+
+# Main Script starts here
+
+run-parts /etc/ppp/ip-up.d
+
+# last line

--- a/recipes-connectivity/ppp/ppp/makefix.patch
+++ b/recipes-connectivity/ppp/ppp/makefix.patch
@@ -1,0 +1,40 @@
+We were seeing reproducibility issues where one host would use the internal 
+logwtmp wrapper, another would use the one in libutil. The issue was that in
+some cases the "\#include" was making it to CC, in others, "#include". The
+issue seems to be related to shell escaping.
+
+The root cause looks to be:
+http://git.savannah.gnu.org/cgit/make.git/commit/?id=c6966b323811c37acedff05b576b907b06aea5f4
+
+Instead of relying on shell quoting, use make to indirect the variable
+and avoid the problem.
+
+See https://github.com/paulusmack/ppp/issues/233
+
+Upstream-Status: Backport [https://github.com/paulusmack/ppp/commit/b4430f7092ececdff2504d5f3393a4c6528c3686]
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+
+Index: ppp-2.4.9/pppd/Makefile.linux
+===================================================================
+--- ppp-2.4.9.orig/pppd/Makefile.linux
++++ ppp-2.4.9/pppd/Makefile.linux
+@@ -80,7 +80,8 @@ PLUGIN=y
+ #USE_SRP=y
+ 
+ # Use libutil; test if logwtmp is declared in <utmp.h> to detect
+-ifeq ($(shell echo '\#include <utmp.h>' | $(CC) -E - 2>/dev/null | grep -q logwtmp && echo yes),yes)
++UTMPHEADER = "\#include <utmp.h>"
++ifeq ($(shell echo $(UTMPHEADER) | $(CC) -E - 2>/dev/null | grep -q logwtmp && echo yes),yes)
+ USE_LIBUTIL=y
+ endif
+ 
+@@ -143,7 +144,8 @@ CFLAGS   += -DHAS_SHADOW
+ #LIBS     += -lshadow $(LIBS)
+ endif
+ 
+-ifeq ($(shell echo '\#include <crypt.h>' | $(CC) -E - >/dev/null 2>&1 && echo yes),yes)
++CRYPTHEADER = "\#include <crypt.h>"
++ifeq ($(shell echo $(CRYPTHEADER) | $(CC) -E - >/dev/null 2>&1 && echo yes),yes)
+ CFLAGS  += -DHAVE_CRYPT_H=1
+ LIBS	+= -lcrypt
+ endif

--- a/recipes-connectivity/ppp/ppp/pap
+++ b/recipes-connectivity/ppp/ppp/pap
@@ -1,0 +1,22 @@
+# You can use this script unmodified to connect to sites which allow
+# authentication via PAP, CHAP and similar protocols.
+# This script can be shared among different pppd peer configurations.
+# To use it, add something like this to your /etc/ppp/peers/ file:
+#
+# connect "/usr/sbin/chat -v -f /etc/chatscripts/pap -T PHONE-NUMBER"
+# user YOUR-USERNAME-IN-PAP-SECRETS
+# noauth
+
+# Uncomment the following line to see the connect speed.
+# It will be logged to stderr or to the file specified with the -r chat option.
+#REPORT		CONNECT
+
+ABORT		BUSY
+ABORT		VOICE
+ABORT		"NO CARRIER"
+ABORT		"NO DIALTONE"
+ABORT		"NO DIAL TONE"
+""		ATZ
+OK		ATDT\T
+CONNECT		""
+

--- a/recipes-connectivity/ppp/ppp/poff
+++ b/recipes-connectivity/ppp/ppp/poff
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Lets see how many pppds are running....
+set -- `cat /var/run/ppp*.pid 2>/dev/null`
+
+case $# in
+  0) # pppd only creates a pid file once ppp is up, so let's try killing pppd
+     # on the assumption that we've not got that far yet.
+     killall pppd
+     ;;
+  1) # If only one was running then it can be killed (apparently killall
+     # caused problems for some, so lets try killing the pid from the file)
+     kill $1
+     ;;
+  *) # More than one! Aieehh.. Dont know which one to kill.
+     echo "More than one pppd running. None stopped"
+     exit 1
+     ;;
+esac
+
+if [ -r /var/run/ppp-quick ]
+then
+    rm -f /var/run/ppp-quick
+fi
+
+exit 0

--- a/recipes-connectivity/ppp/ppp/pon
+++ b/recipes-connectivity/ppp/ppp/pon
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "quick" ]
+then
+    touch /var/run/ppp-quick
+    shift
+fi
+
+/usr/sbin/pppd call ${1:-provider}

--- a/recipes-connectivity/ppp/ppp/ppp@.service
+++ b/recipes-connectivity/ppp/ppp/ppp@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=PPP link to %I
+Before=network.target
+
+[Service]
+ExecStart=@SBINDIR@/pppd call %I nodetach nolog
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/ppp/ppp/ppp_on_boot
+++ b/recipes-connectivity/ppp/ppp/ppp_on_boot
@@ -1,0 +1,21 @@
+###!/bin/sh
+#
+#   Rename this file to ppp_on_boot and pppd will be fired up as
+#   soon as the system comes up, connecting to `provider'.
+#
+#   If you also make this file executable, and replace the first line
+#   with just "#!/bin/sh", the commands below will be executed instead.
+#
+
+# The location of the ppp daemon itself (shouldn't need to be changed)
+PPPD=/usr/sbin/pppd
+
+# The default provider to connect to
+$PPPD call provider
+
+# Additional connections, which would just use settings from
+# /etc/ppp/options.<tty>
+#$PPPD ttyS0
+#$PPPD ttyS1
+#$PPPD ttyS2
+#$PPPD ttyS3

--- a/recipes-connectivity/ppp/ppp/provider
+++ b/recipes-connectivity/ppp/ppp/provider
@@ -1,0 +1,35 @@
+# example configuration for a dialup connection authenticated with PAP or CHAP
+#
+# This is the default configuration used by pon(1) and poff(1).
+# See the manual page pppd(8) for information on all the options.
+
+# MUST CHANGE: replace myusername@realm with the PPP login name given to
+# your by your provider.
+# There should be a matching entry with the password in /etc/ppp/pap-secrets
+# and/or /etc/ppp/chap-secrets.
+user "myusername@realm"
+
+# MUST CHANGE: replace ******** with the phone number of your provider.
+# The /etc/chatscripts/pap chat script may be modified to change the
+# modem initialization string.
+connect "/usr/sbin/chat -v -f /etc/chatscripts/pap -T ********"
+
+# Serial device to which the modem is connected.
+/dev/modem
+
+# Speed of the serial line.
+115200
+
+# Assumes that your IP address is allocated dynamically by the ISP.
+noipdefault
+# Try to get the name server addresses from the ISP.
+usepeerdns
+# Use this connection as the default route.
+defaultroute
+
+# Makes pppd "dial again" when the connection is lost.
+persist
+
+# Do not ask the remote to authenticate.
+noauth
+

--- a/recipes-connectivity/ppp/ppp_2.4.9.bb
+++ b/recipes-connectivity/ppp/ppp_2.4.9.bb
@@ -1,0 +1,96 @@
+SUMMARY = "Point-to-Point Protocol (PPP) support"
+DESCRIPTION = "ppp (Paul's PPP Package) is an open source package which implements \
+the Point-to-Point Protocol (PPP) on Linux and Solaris systems."
+SECTION = "console/network"
+HOMEPAGE = "http://samba.org/ppp/"
+BUGTRACKER = "http://ppp.samba.org/cgi-bin/ppp-bugs"
+DEPENDS = "libpcap openssl virtual/crypt"
+LICENSE = "BSD & GPLv2+ & LGPLv2+ & PD"
+LIC_FILES_CHKSUM = "file://pppd/ccp.c;beginline=1;endline=29;md5=e2c43fe6e81ff77d87dc9c290a424dea \
+                    file://pppd/plugins/passprompt.c;beginline=1;endline=10;md5=3bcbcdbf0e369c9a3e0b8c8275b065d8 \
+                    file://pppd/tdb.c;beginline=1;endline=27;md5=4ca3a9991b011038d085d6675ae7c4e6 \
+                    file://chat/chat.c;beginline=1;endline=15;md5=0d374b8545ee5c62d7aff1acbd38add2"
+
+SRC_URI = "https://download.samba.org/pub/${BPN}/${BP}.tar.gz \
+           file://makefix.patch \
+           file://pon \
+           file://poff \
+           file://init \
+           file://ip-up \
+           file://ip-down \
+           file://08setupdns \
+           file://92removedns \
+           file://pap \
+           file://ppp_on_boot \
+           file://provider \
+           file://ppp@.service \
+           "
+
+SRC_URI[sha256sum] = "f938b35eccde533ea800b15a7445b2f1137da7f88e32a16898d02dee8adc058d"
+
+inherit autotools-brokensep systemd
+
+TARGET_CC_ARCH += " ${LDFLAGS}"
+EXTRA_OEMAKE = "CC='${CC}' STRIPPROG=${STRIP} MANDIR=${D}${datadir}/man/man8 INCDIR=${D}${includedir} LIBDIR=${D}${libdir}/pppd/${PV} BINDIR=${D}${sbindir}"
+EXTRA_OECONF = "--disable-strip"
+
+# Package Makefile computes CFLAGS, referencing COPTS.
+# Typically hard-coded to '-O2 -g' in the Makefile's.
+#
+EXTRA_OEMAKE += ' COPTS="${CFLAGS} -I${STAGING_INCDIR}/openssl -I${S}/include"'
+
+do_configure () {
+	oe_runconf
+}
+
+do_install_append () {
+	make install-etcppp ETCDIR=${D}/${sysconfdir}/ppp
+	mkdir -p ${D}${bindir}/ ${D}${sysconfdir}/init.d
+	mkdir -p ${D}${sysconfdir}/ppp/ip-up.d/
+	mkdir -p ${D}${sysconfdir}/ppp/ip-down.d/
+	install -m 0755 ${WORKDIR}/pon ${D}${bindir}/pon
+	install -m 0755 ${WORKDIR}/poff ${D}${bindir}/poff
+	install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/ppp
+	install -m 0755 ${WORKDIR}/ip-up ${D}${sysconfdir}/ppp/
+	install -m 0755 ${WORKDIR}/ip-down ${D}${sysconfdir}/ppp/
+	install -m 0755 ${WORKDIR}/08setupdns ${D}${sysconfdir}/ppp/ip-up.d/
+	install -m 0755 ${WORKDIR}/92removedns ${D}${sysconfdir}/ppp/ip-down.d/
+	mkdir -p ${D}${sysconfdir}/chatscripts
+	mkdir -p ${D}${sysconfdir}/ppp/peers
+	install -m 0755 ${WORKDIR}/pap ${D}${sysconfdir}/chatscripts
+	install -m 0755 ${WORKDIR}/ppp_on_boot ${D}${sysconfdir}/ppp/ppp_on_boot
+	install -m 0755 ${WORKDIR}/provider ${D}${sysconfdir}/ppp/peers/provider
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/ppp@.service ${D}${systemd_unitdir}/system
+	sed -i -e 's,@SBINDIR@,${sbindir},g' \
+	       ${D}${systemd_unitdir}/system/ppp@.service
+	rm -rf ${D}/${mandir}/man8/man8
+	chmod u+s ${D}${sbindir}/pppd
+}
+
+do_install_append_libc-musl () {
+	install -Dm 0644 ${S}/include/net/ppp_defs.h ${D}${includedir}/net/ppp_defs.h
+}
+
+CONFFILES_${PN} = "${sysconfdir}/ppp/pap-secrets ${sysconfdir}/ppp/chap-secrets ${sysconfdir}/ppp/options"
+PACKAGES =+ "${PN}-oa ${PN}-oe ${PN}-radius ${PN}-winbind ${PN}-minconn ${PN}-password ${PN}-l2tp ${PN}-tools"
+FILES_${PN}        = "${sysconfdir} ${bindir} ${sbindir}/chat ${sbindir}/pppd ${systemd_unitdir}/system/ppp@.service"
+FILES_${PN}-oa       = "${libdir}/pppd/${PV}/pppoatm.so"
+FILES_${PN}-oe       = "${sbindir}/pppoe-discovery ${libdir}/pppd/${PV}/*pppoe.so"
+FILES_${PN}-radius   = "${libdir}/pppd/${PV}/radius.so ${libdir}/pppd/${PV}/radattr.so ${libdir}/pppd/${PV}/radrealms.so"
+FILES_${PN}-winbind  = "${libdir}/pppd/${PV}/winbind.so"
+FILES_${PN}-minconn  = "${libdir}/pppd/${PV}/minconn.so"
+FILES_${PN}-password = "${libdir}/pppd/${PV}/pass*.so"
+FILES_${PN}-l2tp     = "${libdir}/pppd/${PV}/*l2tp.so"
+FILES_${PN}-tools    = "${sbindir}/pppstats ${sbindir}/pppdump"
+SUMMARY_${PN}-oa       = "Plugin for PPP for PPP-over-ATM support"
+SUMMARY_${PN}-oe       = "Plugin for PPP for PPP-over-Ethernet support"
+SUMMARY_${PN}-radius   = "Plugin for PPP for RADIUS support"
+SUMMARY_${PN}-winbind  = "Plugin for PPP to authenticate against Samba or Windows"
+SUMMARY_${PN}-minconn  = "Plugin for PPP to set a delay before the idle timeout applies"
+SUMMARY_${PN}-password = "Plugin for PPP to get passwords via a pipe"
+SUMMARY_${PN}-l2tp     = "Plugin for PPP for l2tp support"
+SUMMARY_${PN}-tools    = "Additional tools for the PPP package"
+
+# Ignore compatibility symlink rp-pppoe.so->pppoe.so
+INSANE_SKIP_${PN}-oe += "dev-so"


### PR DESCRIPTION
Upgrades to 2.4.9 from dunfell standard 2.4.7 primarily for support of option `defaultroute-metric` that came in 2.4.8. It contains also a bunch of other fixes, security fixes and new features, see [README here](https://github.com/ppp-project/ppp/blob/812e8e5c87da4fd84ae7bc5b6a18c85106188eb3/README#L64)

