### PR TITLE
pppd: mark files under ip-up.d and ip-down.d as configuration files

### DIFF
--- a/recipes-connectivity/ppp/ppp_2.4.9.bb
+++ b/recipes-connectivity/ppp/ppp_2.4.9.bb
@@ -72,7 +72,7 @@ do_install_append_libc-musl () {
 	install -Dm 0644 ${S}/include/net/ppp_defs.h ${D}${includedir}/net/ppp_defs.h
 }
 
-CONFFILES_${PN} = "${sysconfdir}/ppp/pap-secrets ${sysconfdir}/ppp/chap-secrets ${sysconfdir}/ppp/options"
+CONFFILES_${PN} = "${sysconfdir}/ppp/pap-secrets ${sysconfdir}/ppp/chap-secrets ${sysconfdir}/ppp/options ${sysconfdir}/ppp/ip-up.d/* ${sysconfdir}/ppp/ip-down.d/*"
 PACKAGES =+ "${PN}-oa ${PN}-oe ${PN}-radius ${PN}-winbind ${PN}-minconn ${PN}-password ${PN}-l2tp ${PN}-tools"
 FILES_${PN}        = "${sysconfdir} ${bindir} ${sbindir}/chat ${sbindir}/pppd ${systemd_unitdir}/system/ppp@.service"
 FILES_${PN}-oa       = "${libdir}/pppd/${PV}/pppoatm.so"


### PR DESCRIPTION
This prevents that an upgrade brutally overwrites them, but will,
if different, create a separate .opkg file instead and leave the
original ones intact.