### PR TITLE
libiec61850: enable preconfigured client in stack for RCB

### DIFF
--- a/recipes-connectivity/libiec61850/libiec61850/0002-Stack_customizations.patch
+++ b/recipes-connectivity/libiec61850/libiec61850/0002-Stack_customizations.patch
@@ -1,0 +1,12 @@
+diff -ruN a/config/stack_config.h b/config/stack_config.h
+--- a/config/stack_config.h	2022-03-11 19:15:52.000000000 +0100
++++ b/config/stack_config.h	2022-08-28 08:53:08.143573344 +0200
+@@ -147,7 +147,7 @@
+ #define CONFIG_IEC61850_BRCB_WITH_RESVTMS 1
+ 
+ /* allow only configured clients (when pre-configured by ClientLN) - note behavior in PIXIT Rp13 */
+-#define CONFIG_IEC61850_RCB_ALLOW_ONLY_PRECONFIGURED_CLIENT 0
++#define CONFIG_IEC61850_RCB_ALLOW_ONLY_PRECONFIGURED_CLIENT 1
+ 
+ /* The default buffer size of buffered RCBs in bytes */
+ #define CONFIG_REPORTING_DEFAULT_REPORT_BUFFER_SIZE 65536

--- a/recipes-connectivity/libiec61850/libiec61850_1.5.1.bb
+++ b/recipes-connectivity/libiec61850/libiec61850_1.5.1.bb
@@ -2,10 +2,11 @@ DESCRIPTION = "libIEC61850, the open-source library for the IEC 61850 protocols"
 LICENSE = "GPL-3.0-or-later"
 HOMEPAGE = "https://libiec61850.com/"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+PR = "r1"
 
 SRC_URI = "https://github.com/mz-automation/libiec61850/archive/refs/tags/v${PV}.tar.gz;sha256sum=b6d7ffac831e7d9aec3470e45e2f1734071859c95cab4cfe99ffd1091776b3cc \
            https://github.com/ARMmbed/mbedtls/archive/refs/tags/mbedtls-2.16.0.tar.gz;sha256sum=cd14ff7b422eac01516973e41252c67c274814783b32fafb91a63ebe946beaff \
-           file://0001-Build_tweaks.patch"
+           file://0001-Build_tweaks.patch file://0002-Stack_customizations.patch"
 
 
 inherit autotools


### PR DESCRIPTION
This enables in the library, as by default is disabled, the feature to configure just a specific IP for RCB and filter inbound connections depending on it.