### PR TITLE
Fix chrony-ntp conflict

### DIFF
--- a/recipes-support/chrony/chrony_4.2.bbappend
+++ b/recipes-support/chrony/chrony_4.2.bbappend
@@ -2,3 +2,4 @@
 inherit pkgconfig
 
 DEPENDS += "nettle gnutls " 
+RCONFLICTS:${PN} = "ntimed"


### PR DESCRIPTION
Chrony conflicts with NTP, as `sntp` is provided by ntp we shoud (??) handle both.

This is related to this MR: https://github.com/fedepell/meta-engicam-nxp/pull/9

We should either merge this PR or discard this in favor of removing `sntp` from `engicam-gwc.bb` 

`snmp` is used only for certification purposes. I think we can safely choose to remove from the default image and eventually add manually in case of need. What do you think?