### PR TITLE
lib60870: upgrade to version 2.3.2

### DIFF
--- a/recipes-connectivity/lib60870/lib60870/0001-Build_tweaks.patch
+++ b/recipes-connectivity/lib60870/lib60870/0001-Build_tweaks.patch
@@ -1,29 +1,21 @@
 diff -ruN a/lib60870-C/make/target_system.mk b/lib60870-C/make/target_system.mk
---- a/lib60870-C/make/target_system.mk	2020-10-16 17:54:26.000000000 +0200
-+++ b/lib60870-C/make/target_system.mk	2021-11-13 18:25:59.222708837 +0100
+--- a/lib60870-C/make/target_system.mk	2023-01-19 14:11:41.188766182 +0100
++++ b/lib60870-C/make/target_system.mk	2023-01-19 14:11:08.180696014 +0100
 @@ -146,8 +146,8 @@
  endif
  
  ifneq ($(TARGET), CLANG-CHECK)
 -CC=$(TOOLCHAIN_PREFIX)gcc
 -CPP=$(TOOLCHAIN_PREFIX)g++
-+#CC=$(TOOLCHAIN_PREFIX)gcc
-+#CPP=$(TOOLCHAIN_PREFIX)g++
++# CC=$(TOOLCHAIN_PREFIX)gcc
++# CPP=$(TOOLCHAIN_PREFIX)g++
  endif
  
  ifeq ($(TARGET), BSD)
 diff -ruN a/lib60870-C/Makefile b/lib60870-C/Makefile
---- a/lib60870-C/Makefile	2022-02-17 12:30:20.315682283 +0100
-+++ b/lib60870-C/Makefile	2022-02-17 12:31:07.620782837 +0100
-@@ -62,6 +62,7 @@
- LIB_API_HEADER_FILES += src/hal/inc/hal_thread.h
- LIB_API_HEADER_FILES += src/hal/inc/hal_socket.h
- LIB_API_HEADER_FILES += src/hal/inc/hal_serial.h
-+LIB_API_HEADER_FILES += src/hal/inc/hal_base.h
- LIB_API_HEADER_FILES += src/inc/api/cs101_information_objects.h
- LIB_API_HEADER_FILES += src/inc/api/cs101_master.h
- LIB_API_HEADER_FILES += src/inc/api/cs101_slave.h
-@@ -141,9 +142,9 @@
+--- a/lib60870-C/Makefile	2023-01-19 14:09:05.009435603 +0100
++++ b/lib60870-C/Makefile	2023-01-19 14:12:10.157827760 +0100
+@@ -143,9 +143,9 @@
  	$(CC) $(CFLAGS) -c $(LIB_INCLUDES) $(TEST_INCLUDES) $(OUTPUT_OPTION) $<
  	
  install:	$(LIB_NAME)

--- a/recipes-connectivity/lib60870/lib60870_2.3.2.bb
+++ b/recipes-connectivity/lib60870/lib60870_2.3.2.bb
@@ -3,8 +3,8 @@ LICENSE = "GPL-3.0-or-later"
 HOMEPAGE = "https://www.mz-automation.de/communication-protocols/iec-60870-5-101-104-c-source-code-library/"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "https://github.com/mz-automation/lib60870/archive/refs/tags/v${PV}.tar.gz;sha256sum=643c30383eb06dbec6536d30252c05fca3830ac138ff9309f18a5d9dc03e0ee8 \
-           https://github.com/ARMmbed/mbedtls/archive/refs/tags/mbedtls-2.16.12.tar.gz;sha256sum=0afb4a4ce5b771f2fb86daee786362fbe48285f05b73cd205f46a224ec031783 \
+SRC_URI = "https://github.com/mz-automation/lib60870/archive/refs/tags/v${PV}.tar.gz;sha256sum=c63f170dc2dd25f7ec85d873be522f23d46838a84b072c8afda4118dfd5fc94d \
+           https://github.com/ARMmbed/mbedtls/archive/refs/tags/mbedtls-2.28.2.tar.gz;sha256sum=1db6d4196178fa9f8264bef5940611cd9febcd5d54ec05f52f1e8400f792b5a4 \
            file://0001-Build_tweaks.patch"
 
 # We need to include in the build the specific mbedtls 2.16.12 version as testing with newer versions
@@ -17,11 +17,11 @@ S = "${WORKDIR}/lib60870-${PV}"
 do_compile() {
    # Prepare mbedtls needed links
    cd ${S}/lib60870-C/dependencies
-   rm -rf mbedtls-2.16.12
-   mkdir mbedtls-2.16.12
-   cd mbedtls-2.16.12
-   ln -s ${WORKDIR}/mbedtls-mbedtls-2.16.12/include
-   ln -s ${WORKDIR}/mbedtls-mbedtls-2.16.12/library
+   rm -rf mbedtls-2.28
+   mkdir mbedtls-2.28
+   cd mbedtls-2.28
+   ln -s ${WORKDIR}/mbedtls-mbedtls-2.28.2/include
+   ln -s ${WORKDIR}/mbedtls-mbedtls-2.28.2/library
 
    # Build
    cd ${S}/lib60870-C


### PR DESCRIPTION
Upgrading to 2.3.2 in meta-gwc, waiting for later move directly to module