### PR TITLE
systemd overrides for chrony and gpsd

### DIFF
--- a/recipes-navigation/gpsd/gpsd_3.19.bbappend
+++ b/recipes-navigation/gpsd/gpsd_3.19.bbappend
@@ -1,0 +1,8 @@
+do_install_append() {
+    # Remove files for init.d and systemd
+    rm -r ${D}/${sysconfdir}/init.d
+    rm -r ${D}/${systemd_unitdir}/system/
+    rm -r ${D}/lib/systemd
+}
+
+SYSTEMD_SERVICE_${PN} = ""

--- a/recipes-support/chrony/chrony_3.5.bbappend
+++ b/recipes-support/chrony/chrony_3.5.bbappend
@@ -1,0 +1,9 @@
+do_install_append() {
+    # System V init scripit and systemd
+    rm -r ${D}${sysconfdir}/init.d
+    rm -r ${D}${systemd_unitdir}/system
+    rm -r ${D}/lib
+}
+
+SYSTEMD_PACKAGES = ""
+SYSTEMD_SERVICE_${PN} = ""


### PR DESCRIPTION
Systemd service files conflicts with gwc's custom services during install. It's better to remove them all