### PR TITLE
fix(security): Backport ppp from kirkstone to fix cves

### DIFF
--- a/recipes-connectivity/ppp/ppp/0001-ppp-fix-build-against-5.15-headers.patch
+++ b/recipes-connectivity/ppp/ppp/0001-ppp-fix-build-against-5.15-headers.patch
@@ -1,0 +1,36 @@
+From aba3273273e826c6dc90f197ca9a3e800e826891 Mon Sep 17 00:00:00 2001
+From: Bruce Ashfield <bruce.ashfield@gmail.com>
+Date: Fri, 5 Nov 2021 12:41:35 -0400
+Subject: [PATCH] ppp: fix build against 5.15 headers
+
+The 5.15 kernel has removed ipx support, along with the userspace
+visible header.
+
+This support wasn't used previously (as it hasn't been very well
+maintained in the kernel for several years), so we can simply
+disable it in our build and wait for upstream to do a release that
+drops the support.
+
+Upstream-Status: Inappropriate [OE-specific configuration/headers]
+
+Signed-off-by: Bruce Ashfield <bruce.ashfield@gmail.com>
+---
+ pppd/Makefile.linux | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pppd/Makefile.linux b/pppd/Makefile.linux
+index 22837c5..23b9b22 100644
+--- a/pppd/Makefile.linux
++++ b/pppd/Makefile.linux
+@@ -91,7 +91,7 @@ MAXOCTETS=y
+ 
+ INCLUDE_DIRS= -I../include
+ 
+-COMPILE_FLAGS= -DHAVE_PATHS_H -DIPX_CHANGE -DHAVE_MMAP -pipe
++COMPILE_FLAGS= -DHAVE_PATHS_H -DHAVE_MMAP -pipe
+ 
+ CFLAGS= $(COPTS) $(COMPILE_FLAGS) $(INCLUDE_DIRS) '-DDESTDIR="@DESTDIR@"'
+ 
+-- 
+2.25.1
+

--- a/recipes-connectivity/ppp/ppp/CVE-2022-4603.patch
+++ b/recipes-connectivity/ppp/ppp/CVE-2022-4603.patch
@@ -1,0 +1,48 @@
+From a75fb7b198eed50d769c80c36629f38346882cbf Mon Sep 17 00:00:00 2001
+From: Paul Mackerras <paulus@ozlabs.org>
+Date: Thu, 4 Aug 2022 12:23:08 +1000
+Subject: [PATCH] pppdump: Avoid out-of-range access to packet buffer
+
+This fixes a potential vulnerability where data is written to spkt.buf
+and rpkt.buf without a check on the array index.  To fix this, we
+check the array index (pkt->cnt) before storing the byte or
+incrementing the count.  This also means we no longer have a potential
+signed integer overflow on the increment of pkt->cnt.
+
+Fortunately, pppdump is not used in the normal process of setting up a
+PPP connection, is not installed setuid-root, and is not invoked
+automatically in any scenario that I am aware of.
+
+Signed-off-by: Paul Mackerras <paulus@ozlabs.org>
+
+Upstream-Status: Backport
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+---
+ pppdump/pppdump.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/pppdump/pppdump.c b/pppdump/pppdump.c
+index 2b815fc9..b85a8627 100644
+--- a/pppdump/pppdump.c
++++ b/pppdump/pppdump.c
+@@ -297,6 +297,10 @@ dumpppp(f)
+ 			    printf("%s aborted packet:\n     ", dir);
+ 			    q = "    ";
+ 			}
++			if (pkt->cnt >= sizeof(pkt->buf)) {
++			    printf("%s over-long packet truncated:\n     ", dir);
++			    q = "    ";
++			}
+ 			nb = pkt->cnt;
+ 			p = pkt->buf;
+ 			pkt->cnt = 0;
+@@ -400,7 +404,8 @@ dumpppp(f)
+ 			c ^= 0x20;
+ 			pkt->esc = 0;
+ 		    }
+-		    pkt->buf[pkt->cnt++] = c;
++		    if (pkt->cnt < sizeof(pkt->buf))
++			pkt->buf[pkt->cnt++] = c;
+ 		    break;
+ 		}
+ 	    }

--- a/recipes-connectivity/ppp/ppp/CVE-2024-58250.patch
+++ b/recipes-connectivity/ppp/ppp/CVE-2024-58250.patch
@@ -1,0 +1,185 @@
+From 0a66ad22e54c72690ec2a29a019767c55c5281fc Mon Sep 17 00:00:00 2001
+From: Paul Mackerras <paulus@ozlabs.org>
+Date: Fri, 18 Oct 2024 20:22:57 +1100
+Subject: [PATCH] pppd: Remove passprompt plugin
+
+This is prompted by a number of factors:
+
+* It was more useful back in the dial-up days, but no-one uses dial-up
+  any more
+
+* In many cases there will be no terminal accessible to the prompter
+  program at the point where the prompter is run
+
+* The passwordfd plugin does much the same thing but does it more
+  cleanly and securely
+
+* The handling of privileges and file descriptors needs to be audited
+  thoroughly.
+
+Signed-off-by: Paul Mackerras <paulus@ozlabs.org>
+
+CVE: CVE-2024-58250
+Upstream-Status: Backport [https://github.com/ppp-project/ppp/commit/0a66ad22e54c72690ec2a29a019767c55c5281fc]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+---
+ pppd/plugins/Makefile.linux |   2 +-
+ pppd/plugins/Makefile.sol2  |   6 --
+ pppd/plugins/passprompt.c   | 119 ------------------------------------
+ 3 files changed, 1 insertion(+), 126 deletions(-)
+ delete mode 100644 pppd/plugins/passprompt.c
+
+diff --git a/pppd/plugins/Makefile.linux b/pppd/plugins/Makefile.linux
+index 6403e3d..fcc36e4 100644
+--- a/pppd/plugins/Makefile.linux
++++ b/pppd/plugins/Makefile.linux
+@@ -17,7 +17,7 @@ CFLAGS += -DUSE_EAPTLS=1
+ SUBDIRS := pppoe pppoatm pppol2tp
+ # Uncomment the next line to include the radius authentication plugin
+ SUBDIRS += radius
+-PLUGINS := minconn.so passprompt.so passwordfd.so winbind.so
++PLUGINS := minconn.so passwordfd.so winbind.so
+ 
+ # This setting should match the one in ../Makefile.linux
+ MPPE=y
+diff --git a/pppd/plugins/Makefile.sol2 b/pppd/plugins/Makefile.sol2
+index bc7d85d..f77ea1d 100644
+--- a/pppd/plugins/Makefile.sol2
++++ b/pppd/plugins/Makefile.sol2
+@@ -17,11 +17,5 @@ minconn.so: minconn.o
+ minconn.o: minconn.c
+ 	$(CC) $(CFLAGS) -c $? 
+ 
+-passprompt.so: passprompt.o
+-	ld -o $@ $(LDFLAGS) -h $@ passprompt.o
+-
+-passprompt.o: passprompt.c
+-	$(CC) $(CFLAGS) -c $?
+-
+ clean:
+ 	rm -f *.o *.so
+diff --git a/pppd/plugins/passprompt.c b/pppd/plugins/passprompt.c
+deleted file mode 100644
+index 7779d51..0000000
+--- a/pppd/plugins/passprompt.c
++++ /dev/null
+@@ -1,119 +0,0 @@
+-/*
+- * passprompt.c - pppd plugin to invoke an external PAP password prompter
+- *
+- * Copyright 1999 Paul Mackerras, Alan Curry.
+- *
+- *  This program is free software; you can redistribute it and/or
+- *  modify it under the terms of the GNU General Public License
+- *  as published by the Free Software Foundation; either version
+- *  2 of the License, or (at your option) any later version.
+- */
+-#include <errno.h>
+-#include <unistd.h>
+-#include <sys/wait.h>
+-#include <syslog.h>
+-#include "pppd.h"
+-
+-char pppd_version[] = VERSION;
+-
+-static char promptprog[PATH_MAX+1];
+-static int promptprog_refused = 0;
+-
+-static option_t options[] = {
+-    { "promptprog", o_string, promptprog,
+-      "External PAP password prompting program",
+-      OPT_STATIC, NULL, PATH_MAX },
+-    { NULL }
+-};
+-
+-static int promptpass(char *user, char *passwd)
+-{
+-    int p[2];
+-    pid_t kid;
+-    int readgood, wstat;
+-    ssize_t red;
+-
+-    if (promptprog_refused || promptprog[0] == 0 || access(promptprog, X_OK) < 0)
+-	return -1;	/* sorry, can't help */
+-
+-    if (!passwd)
+-	return 1;
+-
+-    if (pipe(p)) {
+-	warn("Can't make a pipe for %s", promptprog);
+-	return 0;
+-    }
+-    if ((kid = fork()) == (pid_t) -1) {
+-	warn("Can't fork to run %s", promptprog);
+-	close(p[0]);
+-	close(p[1]);
+-	return 0;
+-    }
+-    if (!kid) {
+-	/* we are the child, exec the program */
+-	char *argv[5], fdstr[32];
+-	sys_close();
+-	closelog();
+-	close(p[0]);
+-	seteuid(getuid());
+-	setegid(getgid());
+-	argv[0] = promptprog;
+-	argv[1] = user;
+-	argv[2] = remote_name;
+-	sprintf(fdstr, "%d", p[1]);
+-	argv[3] = fdstr;
+-	argv[4] = 0;
+-	execv(*argv, argv);
+-	_exit(127);
+-    }
+-
+-    /* we are the parent, read the password from the pipe */
+-    close(p[1]);
+-    readgood = 0;
+-    do {
+-	red = read(p[0], passwd + readgood, MAXSECRETLEN-1 - readgood);
+-	if (red == 0)
+-	    break;
+-	if (red < 0) {
+-	    if (errno == EINTR && !got_sigterm)
+-		continue;
+-	    error("Can't read secret from %s: %m", promptprog);
+-	    readgood = -1;
+-	    break;
+-	}
+-	readgood += red;
+-    } while (readgood < MAXSECRETLEN - 1);
+-    close(p[0]);
+-
+-    /* now wait for child to exit */
+-    while (waitpid(kid, &wstat, 0) < 0) {
+-	if (errno != EINTR || got_sigterm) {
+-	    warn("error waiting for %s: %m", promptprog);
+-	    break;
+-	}
+-    }
+-
+-    if (readgood < 0)
+-	return 0;
+-    passwd[readgood] = 0;
+-    if (!WIFEXITED(wstat))
+-	warn("%s terminated abnormally", promptprog);
+-    if (WEXITSTATUS(wstat)) {
+-	    warn("%s exited with code %d", promptprog, WEXITSTATUS(wstat));
+-	    /* code when cancel was hit in the prompt prog */
+-	    if (WEXITSTATUS(wstat) == 128) {
+-	        promptprog_refused = 1;
+-	    }
+-	    return -1;
+-    }
+-    return 1;
+-}
+-
+-void plugin_init(void)
+-{
+-    add_options(options);
+-    pap_passwd_hook = promptpass;
+-#ifdef USE_EAPTLS
+-    eaptls_passwd_hook = promptpass;
+-#endif
+-}

--- a/recipes-connectivity/ppp/ppp_2.4.9.bb
+++ b/recipes-connectivity/ppp/ppp_2.4.9.bb
@@ -5,9 +5,8 @@ SECTION = "console/network"
 HOMEPAGE = "http://samba.org/ppp/"
 BUGTRACKER = "http://ppp.samba.org/cgi-bin/ppp-bugs"
 DEPENDS = "libpcap openssl virtual/crypt"
-LICENSE = "BSD & GPLv2+ & LGPLv2+ & PD"
+LICENSE = "BSD-3-Clause & BSD-3-Clause-Attribution & GPL-2.0-or-later & LGPL-2.0-or-later & PD & RSA-MD"
 LIC_FILES_CHKSUM = "file://pppd/ccp.c;beginline=1;endline=29;md5=e2c43fe6e81ff77d87dc9c290a424dea \
-                    file://pppd/plugins/passprompt.c;beginline=1;endline=10;md5=3bcbcdbf0e369c9a3e0b8c8275b065d8 \
                     file://pppd/tdb.c;beginline=1;endline=27;md5=4ca3a9991b011038d085d6675ae7c4e6 \
                     file://chat/chat.c;beginline=1;endline=15;md5=0d374b8545ee5c62d7aff1acbd38add2"
 
@@ -24,6 +23,9 @@ SRC_URI = "https://download.samba.org/pub/${BPN}/${BP}.tar.gz \
            file://ppp_on_boot \
            file://provider \
            file://ppp@.service \
+           file://0001-ppp-fix-build-against-5.15-headers.patch \
+           file://CVE-2022-4603.patch \
+           file://CVE-2024-58250.patch \
            "
 
 SRC_URI[sha256sum] = "f938b35eccde533ea800b15a7445b2f1137da7f88e32a16898d02dee8adc058d"


### PR DESCRIPTION
Fix CVEs:
- CVE-2022-4603.patch
- CVE-2024-58250.patch

Upstream source: https://github.com/yoctoproject/poky/tree/34ee6fc4949f4a7adb4ceb0f51fb327093b8b491/meta/recipes-connectivity/ppp